### PR TITLE
Do not mangle key name if it contains the root directory name.

### DIFF
--- a/mock_s3/file_store.py
+++ b/mock_s3/file_store.py
@@ -77,7 +77,7 @@ class FileStore(object):
                     if config.has_option('metadata', 'modified_date'):
                         metadata['modified_date'] = config.get('metadata', 'modified_date')
 
-                actual_key = root.replace(self.root, '')
+                actual_key = root.replace(self.root, '', 1)
                 actual_key = actual_key.replace('/' + bucket.name + '/', '')
                 matches.append(S3Item(actual_key, **metadata))
                 if len(matches) >= max_keys:


### PR DESCRIPTION
If you have a key that contains the root directory name as a substring,
the root directory name will be removed from the key name, and the
returned key name will be wrong.
Example:
root directory: /data
key name: foo/database/file

will return a key "foo/base/file" in a list keys operation.
This will cause GET operations and prefix searches to return the
wrong result to the client.

Fix by only replacing the first occurrence of the root directory
from the file name.